### PR TITLE
Ensure root is in allowed users

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -452,7 +452,7 @@ class ssh::config (
   Array[String] $kex_algorithms = $::ssh::params::kex_algorithms,
   Array[String] $ciphers = $::ssh::params::ciphers,
   Array[String] $macs = $::ssh::params::macs,
-  Array[String] $allow_users = [],
+  Array[String] $allow_users = $::ssh::params::allow_users,
   Array[String] $allow_groups = [],
   Array[String] $deny_users = [],
   Array[String] $deny_groups = [],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -155,6 +155,9 @@ class ssh::params {
     'ssh-rsa',
   ]
   $permit_user_rc = true
+  $allow_users = [
+    'root'
+  ]
 
   case $::osfamily {
     'Debian': {


### PR DESCRIPTION
Make sure 'root' is in the allowed users in the config or else you will not be allowed in if you allow root login 'without-password', i.e. with a cert.